### PR TITLE
Remove the 2 suffix

### DIFF
--- a/1-Feature_extraction.ipynb
+++ b/1-Feature_extraction.ipynb
@@ -759,7 +759,7 @@
    "outputs": [],
    "source": [
     "# Store file\n",
-    "train_data_expand.to_csv('trainDataFeatures2.tsv', sep='\\t')"
+    "train_data_expand.to_csv('trainDataFeatures.tsv', sep='\\t')"
    ]
   }
  ],


### PR DESCRIPTION
Simply remove the 2 from the name of the training data feature TSV.
